### PR TITLE
Roboenza Reactor Support

### DIFF
--- a/RotM-pk3/Actors/ObjectiveCombo/RoboenzaReactor.txt
+++ b/RotM-pk3/Actors/ObjectiveCombo/RoboenzaReactor.txt
@@ -1,0 +1,27 @@
+actor RReactorBase //use this actor to mimmick player pain states and protections
+{
+Species "WilyTeam"
+
+damagefactor "Dummy", 0.0
+
+damagefactor "TenguDash", 0.10
+States
+{
+Pain.SpreadDrill:
+Pain.SpreadDrill2:
+Pain.SpreadDrill3:
+PLY1 H 0 A_GiveInventory("SpreadDrillProtect", 1)
+TNT1 A 1 A_Jump(256,"SpawnLoop")
+wait
+
+Pain.FlameSword:
+PLY1 H 0 A_GiveInventory("FlameSwordProtect", 1)
+TNT1 A 1 A_Jump(256,"SpawnLoop")
+wait
+
+pain.LaserTrident:
+PLY1 H 0 A_GiveInventory("LaserTridentProtect", 1)
+TNT1 A 1 A_Jump(256,"SpawnLoop")
+wait
+}
+}


### PR DESCRIPTION
New framework and startup means it's easier to implement these systems that'll need some updating as things are added. This actor can be updated with pain states that use PowerProtects to ensure proper compatibility with hosting Objective Combo. It's harmless to the mod itself though as it's not being loaded under normal circumstances. Only when RotM is hosted after ObjC will this file be loaded.